### PR TITLE
refactor: conditionally append user coordinates to URL

### DIFF
--- a/src/services/restaurant.service.ts
+++ b/src/services/restaurant.service.ts
@@ -23,7 +23,11 @@ export const analyzeImage = async (
     formData.append('file', file);
 
     const response = await apiService.post<ApiResponse<Restaurant[]>>(
-      `image-search?top_n=${topN}&user_lat=${userCoords?.latitude}&user_long=${userCoords?.longitude}`,
+      `image-search?top_n=${topN}${
+        userCoords 
+          ? `&user_lat=${userCoords.latitude}&user_long=${userCoords.longitude}`
+          : ''
+      }`,
       formData,
       {
         headers: {


### PR DESCRIPTION
This change ensures that user coordinates are only appended to the image-search URL if they are provided, avoiding unnecessary query parameters when userCoords is undefined. This improves the cleanliness and efficiency of the API request.