### PR TITLE
chore: remove @tanstack/react-query and devtools dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,43 @@
 # Grab Bootcamp Frontend Project
 
-This project is a frontend application built with React and Vite.
+This project is a modern frontend application built with React and Vite, designed to help users find restaurants by uploading a food image. It leverages image analysis to identify dishes and provides relevant restaurant information, including menus and reviews.
+
+## Table of Contents
+
+- [Features](#features)
+- [Technologies Used](#technologies-used)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Running the Project](#running-the-project)
+  - [Building the Project](#building-the-project)
+  - [Linting and Formatting](#linting-and-formatting)
+- [Project Structure](#project-structure)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Features
+
+- **Image-based Restaurant Search:** Upload a food image to find restaurants serving that dish.
+- **Restaurant Details:** View detailed information about restaurants, including menu items, reviews, and location.
+- **User Authentication:** Secure sign-up and sign-in functionality.
+- **Responsive Design:** Optimized for various screen sizes using Emotion for styling.
+- **State Management:** Utilizes Redux Toolkit for efficient state management.
+- **Modern UI:** Built with Ant Design components for a clean and professional look.
+
+## Technologies Used
+
+- **React:** A JavaScript library for building user interfaces.
+- **Vite:** A fast build tool for modern web projects.
+- **TypeScript:** A typed superset of JavaScript that compiles to plain JavaScript.
+- **Ant Design:** A popular React UI library.
+- **Emotion:** A library for writing CSS with JavaScript.
+- **Redux Toolkit:** The standard way to write Redux logic.
+- **React Router DOM:** For declarative routing in React applications.
+- **Axios:** A promise-based HTTP client.
+- **Dayjs:** A minimalist JavaScript library for parsing, validating, manipulating, and formatting dates.
+- **React Hook Form:** For flexible and extensible forms with easy validation.
+- **Polished:** A lightweight style helper library for writing styles in JavaScript.
 
 ## Getting Started
 
@@ -13,23 +50,23 @@ Follow these instructions to get the project up and running on your local machin
 
 ### Installation
 
-1.  Clone the repository:
-    ```bash
-    git clone <repository-url>
-    cd grab-bootcamp-frontend
-    ```
-2.  Install the dependencies using yarn or npm:
-    ```bash
-    yarn install
-    ```
-    or
-    ```bash
-    npm install
-    ```
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/thvnhtai/grab-bootcamp-frontend.git
+   cd grab-bootcamp-frontend
+   ```
+2. Install the dependencies using yarn or npm:
+   ```bash
+   yarn install
+   ```
+   or
+   ```bash
+   npm install
+   ```
 
-### Running the Development Server
+### Running the Project
 
-To start the application in development mode, run:
+To start the development server:
 
 ```bash
 yarn dev
@@ -40,3 +77,120 @@ or
 ```bash
 npm run dev
 ```
+
+Open your browser and navigate to `http://localhost:5173` (or the port indicated in your terminal).
+
+### Building the Project
+
+To build the project for production:
+
+```bash
+yarn build
+```
+
+or
+
+```bash
+npm run build
+```
+
+This will generate the production-ready files in the `dist` directory.
+
+### Linting and Formatting
+
+To check for linting errors:
+
+```bash
+yarn lint
+```
+
+or
+
+```bash
+npm run lint
+```
+
+To check code formatting:
+
+```bash
+yarn prettier
+```
+
+or
+
+```bash
+npm run prettier
+```
+
+To automatically fix formatting issues:
+
+```bash
+yarn prettier:fix
+```
+
+or
+
+```bash
+npm run prettier:fix
+```
+
+## Project Structure
+
+The project follows a standard React application structure:
+
+```
+grab-bootcamp-frontend/
+├── public/
+├── src/
+│   ├── assets/
+│   ├── components/       # Reusable UI components
+│   │   ├── common/
+│   │   ├── forms/
+│   │   ├── layout/
+│   │   ├── restaurant/
+│   │   ├── static/
+│   │   └── utility/
+│   ├── constants/      # Application constants
+│   ├── enums/          # Enums
+│   ├── hooks/          # Custom React hooks
+│   ├── layouts/        # Page layouts
+│   ├── pages/          # Application pages
+│   │   ├── auth/
+│   │   ├── home/
+│   │   ├── search/
+│   │   └── search-result/
+│   ├── providers/      # Context and state providers
+│   ├── redux/          # Redux store and slices
+│   ├── services/       # API service calls
+│   ├── types/          # TypeScript type definitions
+│   ├── utils/          # Utility functions
+│   ├── App.tsx         # Main application component
+│   ├── index.css       # Global styles
+│   └── main.tsx        # Entry point
+├── .eslintrc.js        # ESLint configuration
+├── .gitignore          # Git ignore file
+├── .prettierrc         # Prettier configuration
+├── index.html          # HTML entry file
+├── package.json        # Project dependencies and scripts
+├── tsconfig.json       # TypeScript configuration
+├── tsconfig.app.json
+├── tsconfig.node.json
+└── vite.config.ts      # Vite configuration
+```
+
+## Contributing
+
+Contributions are welcome! Please follow these steps:
+
+1. Fork the repository.
+2. Create a new branch (`git checkout -b feature/your-feature-name`).
+3. Make your changes.
+4. Commit your changes (`git commit -m 'feat: Add new feature'`).
+5. Push to the branch (`git push origin feature/your-feature-name`).
+6. Create a new Pull Request.
+
+Please ensure your code adheres to the project's linting and formatting standards.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "@emotion/styled": "^11.14.0",
     "@heroicons/react": "^2.2.0",
     "@reduxjs/toolkit": "^2.7.0",
-    "@tanstack/react-query": "^5.67.3",
-    "@tanstack/react-query-devtools": "^5.67.3",
     "antd": "^5.24.3",
     "axios": "^1.8.3",
     "dayjs": "^1.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,30 +1002,6 @@
     "@svgr/hast-util-to-babel-ast" "8.0.0"
     svg-parser "^2.0.4"
 
-"@tanstack/query-core@5.67.3":
-  version "5.67.3"
-  resolved "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.3.tgz"
-  integrity sha512-pq76ObpjcaspAW4OmCbpXLF6BCZP2Zr/J5ztnyizXhSlNe7fIUp0QKZsd0JMkw9aDa+vxDX/OY7N+hjNY/dCGg==
-
-"@tanstack/query-devtools@5.67.2":
-  version "5.67.2"
-  resolved "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.67.2.tgz"
-  integrity sha512-O4QXFFd7xqp6EX7sdvc9tsVO8nm4lpWBqwpgjpVLW5g7IeOY6VnS/xvs/YzbRhBVkKTMaJMOUGU7NhSX+YGoNg==
-
-"@tanstack/react-query-devtools@^5.67.3":
-  version "5.67.3"
-  resolved "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.67.3.tgz"
-  integrity sha512-+PM2UnCyXAQozXB32cnawx38wwnaHPTtFAhX1V5QmHy/FL1u9k7nd8nxn2+GTwf15SGbUaGfxA/vq/9EARUEIQ==
-  dependencies:
-    "@tanstack/query-devtools" "5.67.2"
-
-"@tanstack/react-query@^5.67.3":
-  version "5.67.3"
-  resolved "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.3.tgz"
-  integrity sha512-u/n2HsQeH1vpZIOzB/w2lqKlXUDUKo6BxTdGXSMvNzIq5MHYFckRMVuFABp+QB7RN8LFXWV6X1/oSkuDq+MPIA==
-  dependencies:
-    "@tanstack/query-core" "5.67.3"
-
 "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz"


### PR DESCRIPTION
This commit removes the @tanstack/react-query and @tanstack/react-query-devtools dependencies from the project. These dependencies are no longer needed as the project has shifted to using Redux Toolkit for state management. Additionally, the README.md file has been updated to provide a more detailed description of the project, its features, and technologies used.